### PR TITLE
Implement Firestore-based frontenis stats

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -1,95 +1,157 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="es" class="scroll-smooth">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ISSEA | Torneo de Frontenis</title>
+    <title>Torneo de Frontenis ISSEA</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 p-4">
-    <h1 class="text-3xl font-bold mb-4">Administrador de Torneo de Frontenis (ISSEA)</h1>
+<body class="bg-gray-50 p-4 max-w-2xl mx-auto">
+    <h1 class="text-2xl font-bold text-center mb-6">Administrador Torneo Frontenis ISSEA</h1>
 
-    <section id="players" class="mb-8">
-        <h2 class="text-xl font-semibold mb-2">Jugadores</h2>
-        <form id="playerForm" class="mb-2">
-            <input type="text" id="playerName" placeholder="Nombre del jugador" class="border p-2 mr-2">
-            <button type="submit" class="bg-blue-500 text-white px-4 py-2">Agregar</button>
+    <section id="pairSection" class="mb-10">
+        <h2 class="text-xl font-semibold mb-2">Agregar Pareja</h2>
+        <form id="pairForm" class="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-4">
+            <input id="zagueroName" placeholder="Zaguero" class="border p-2 rounded" />
+            <input id="delanteroName" placeholder="Delantero" class="border p-2 rounded" />
+            <button type="submit" class="bg-blue-500 text-white rounded p-2">Agregar</button>
         </form>
-        <ul id="playerList" class="list-disc pl-5"></ul>
+        <ul id="pairList" class="mt-4 space-y-1 text-sm"></ul>
     </section>
 
-    <section id="schedule" class="mb-8">
-        <h2 class="text-xl font-semibold mb-2">Rol de Juegos</h2>
-        <button id="generateSchedule" class="bg-green-500 text-white px-4 py-2 mb-2">Generar rol de juegos</button>
-        <ul id="scheduleList" class="list-decimal pl-5"></ul>
+    <section id="matchSection" class="mb-10">
+        <h2 class="text-xl font-semibold mb-2">Registrar Partido</h2>
+        <form id="matchForm" class="grid grid-cols-2 gap-2 items-center">
+            <select id="pairA" class="border p-2 rounded"></select>
+            <input id="scoreA" type="number" min="0" class="border p-2 rounded" />
+            <span class="col-span-2 text-center">vs</span>
+            <select id="pairB" class="border p-2 rounded"></select>
+            <input id="scoreB" type="number" min="0" class="border p-2 rounded" />
+            <button type="submit" class="bg-green-600 text-white rounded p-2 col-span-2">Registrar</button>
+        </form>
     </section>
 
-    <section id="bracket" class="mb-8">
-        <h2 class="text-xl font-semibold mb-2">Eliminatoria</h2>
-        <button id="generateBracket" class="bg-purple-500 text-white px-4 py-2 mb-2">Generar Eliminatoria</button>
-        <div id="bracketContainer" class="pl-5"></div>
+    <section id="statsSection" class="mb-10">
+        <h2 class="text-xl font-semibold mb-2">Estadísticas</h2>
+        <div class="overflow-x-auto">
+            <table class="min-w-full text-sm text-left">
+                <thead>
+                    <tr class="border-b">
+                        <th class="px-2 py-1">Pareja</th>
+                        <th class="px-2 py-1">JJ</th>
+                        <th class="px-2 py-1">JG</th>
+                        <th class="px-2 py-1">JP</th>
+                        <th class="px-2 py-1">PF</th>
+                        <th class="px-2 py-1">PC</th>
+                    </tr>
+                </thead>
+                <tbody id="statsBody"></tbody>
+            </table>
+        </div>
     </section>
 
-    <script>
-    let players = JSON.parse(localStorage.getItem('frontenisPlayers')) || [];
-    const playerList = document.getElementById('playerList');
+<script type="module">
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js';
+import { getFirestore, collection, addDoc, getDocs, onSnapshot } from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
 
-    function renderPlayers() {
-        playerList.innerHTML = '';
-        players.forEach((player, index) => {
-            const li = document.createElement('li');
-            li.className = 'flex items-center mb-1';
-            li.textContent = player;
-            const removeBtn = document.createElement('button');
-            removeBtn.textContent = 'x';
-            removeBtn.className = 'ml-2 text-red-500';
-            removeBtn.onclick = () => {
-                players.splice(index, 1);
-                localStorage.setItem('frontenisPlayers', JSON.stringify(players));
-                renderPlayers();
-            };
-            li.appendChild(removeBtn);
-            playerList.appendChild(li);
-        });
-    }
-    renderPlayers();
+// TODO: Reemplaza con la configuración de tu proyecto Firebase
+const firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "YOUR_PROJECT.firebaseapp.com",
+    projectId: "YOUR_PROJECT_ID",
+    storageBucket: "YOUR_PROJECT.appspot.com",
+    messagingSenderId: "YOUR_SENDER_ID",
+    appId: "YOUR_APP_ID"
+};
 
-    document.getElementById('playerForm').onsubmit = e => {
-        e.preventDefault();
-        const name = document.getElementById('playerName').value.trim();
-        if (name) {
-            players.push(name);
-            document.getElementById('playerName').value = '';
-            localStorage.setItem('frontenisPlayers', JSON.stringify(players));
-            renderPlayers();
-        }
-    };
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
 
-    document.getElementById('generateSchedule').onclick = () => {
-        if (players.length < 2) return alert('Se necesitan al menos dos jugadores');
-        const scheduleList = document.getElementById('scheduleList');
-        scheduleList.innerHTML = '';
-        for (let i = 0; i < players.length; i++) {
-            for (let j = i + 1; j < players.length; j++) {
-                const li = document.createElement('li');
-                li.textContent = players[i] + ' vs ' + players[j];
-                scheduleList.appendChild(li);
-            }
-        }
-    };
+const pairForm = document.getElementById('pairForm');
+const zagueroInput = document.getElementById('zagueroName');
+const delanteroInput = document.getElementById('delanteroName');
+const pairList = document.getElementById('pairList');
+const pairASelect = document.getElementById('pairA');
+const pairBSelect = document.getElementById('pairB');
+const matchForm = document.getElementById('matchForm');
+const statsBody = document.getElementById('statsBody');
 
-    document.getElementById('generateBracket').onclick = () => {
-        if (players.length < 2) return alert('Se necesitan al menos dos jugadores');
-        const container = document.getElementById('bracketContainer');
-        container.innerHTML = '';
-        for (let i = 0; i < players.length; i += 2) {
-            const p1 = players[i];
-            const p2 = players[i + 1] || 'BYE';
-            const div = document.createElement('div');
-            div.textContent = p1 + ' vs ' + p2;
-            container.appendChild(div);
-        }
-    };
-    </script>
+pairForm.onsubmit = async e => {
+    e.preventDefault();
+    const zaguero = zagueroInput.value.trim();
+    const delantero = delanteroInput.value.trim();
+    if (!zaguero || !delantero) return;
+    await addDoc(collection(db, 'pairs'), { zaguero, delantero });
+    zagueroInput.value = '';
+    delanteroInput.value = '';
+};
+
+matchForm.onsubmit = async e => {
+    e.preventDefault();
+    const pairA = pairASelect.value;
+    const pairB = pairBSelect.value;
+    const scoreA = parseInt(document.getElementById('scoreA').value) || 0;
+    const scoreB = parseInt(document.getElementById('scoreB').value) || 0;
+    if (!pairA || !pairB || pairA === pairB) return;
+    await addDoc(collection(db, 'matches'), { pairA, pairB, scoreA, scoreB, ts: Date.now() });
+    matchForm.reset();
+};
+
+function renderPairs(pairs) {
+    pairList.innerHTML = '';
+    pairASelect.innerHTML = '<option value="">Pareja A</option>';
+    pairBSelect.innerHTML = '<option value="">Pareja B</option>';
+    pairs.forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = `${p.zaguero} / ${p.delantero}`;
+        pairList.appendChild(li);
+
+        const optA = document.createElement('option');
+        optA.value = p.id;
+        optA.textContent = `${p.zaguero} / ${p.delantero}`;
+        pairASelect.appendChild(optA);
+        const optB = optA.cloneNode(true);
+        pairBSelect.appendChild(optB);
+    });
+}
+
+function computeStats(pairs, matches) {
+    const stats = {};
+    pairs.forEach(p => stats[p.id] = { name: `${p.zaguero} / ${p.delantero}`, jj:0, jg:0, jp:0, pf:0, pc:0 });
+    matches.forEach(m => {
+        const a = stats[m.pairA];
+        const b = stats[m.pairB];
+        if (!a || !b) return;
+        a.jj++; b.jj++;
+        a.pf += m.scoreA; a.pc += m.scoreB;
+        b.pf += m.scoreB; b.pc += m.scoreA;
+        if (m.scoreA > m.scoreB) { a.jg++; b.jp++; }
+        else if (m.scoreB > m.scoreA) { b.jg++; a.jp++; }
+    });
+    return Object.values(stats);
+}
+
+function renderStats(stats) {
+    statsBody.innerHTML = '';
+    stats.forEach(s => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td class="px-2 py-1">${s.name}</td><td>${s.jj}</td><td>${s.jg}</td><td>${s.jp}</td><td>${s.pf}</td><td>${s.pc}</td>`;
+        statsBody.appendChild(tr);
+    });
+}
+
+async function loadData() {
+    const pairSnap = await getDocs(collection(db, 'pairs'));
+    const pairs = pairSnap.docs.map(d => ({ id: d.id, ...d.data() }));
+    const matchSnap = await getDocs(collection(db, 'matches'));
+    const matches = matchSnap.docs.map(d => d.data());
+    renderPairs(pairs);
+    renderStats(computeStats(pairs, matches));
+}
+
+onSnapshot(collection(db, 'pairs'), loadData);
+onSnapshot(collection(db, 'matches'), loadData);
+loadData();
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@
                     <li><a href="#como-trabajamos" class="text-gray-600 hover:vortex-blue font-semibold transition-colors duration-300">Cómo trabajamos</a></li>
                     <li><a href="#galeria" class="text-gray-600 hover:vortex-blue font-semibold transition-colors duration-300">Galería</a></li>
                     <li><a href="#asesores" class="text-gray-600 hover:vortex-blue font-semibold transition-colors duration-300">Asesores</a></li>
+                    <li><a href="frontenis.html" class="text-gray-600 hover:vortex-blue font-semibold transition-colors duration-300">Torneo Frontenis</a></li>
                     <li><a href="#contacto" class="text-gray-600 hover:vortex-blue font-semibold transition-colors duration-300">Contáctanos</a></li>
                 </ul>
             </nav>
@@ -180,6 +181,7 @@
                                 <li><a href="#como-trabajamos" class="mobile-menu-link block text-gray-700 hover:vortex-blue font-semibold text-lg">Cómo trabajamos</a></li>
                                 <li><a href="#galeria" class="mobile-menu-link block text-gray-700 hover:vortex-blue font-semibold text-lg">Galería</a></li>
                                 <li><a href="#asesores" class="mobile-menu-link block text-gray-700 hover:vortex-blue font-semibold text-lg">Asesores</a></li>
+                                <li><a href="frontenis.html" class="mobile-menu-link block text-gray-700 hover:vortex-blue font-semibold text-lg">Torneo Frontenis</a></li>
                                 <li><a href="#contacto" class="mobile-menu-link block text-gray-700 hover:vortex-blue font-semibold text-lg">Contáctanos</a></li>
                             </ul>
                         </nav>


### PR DESCRIPTION
## Summary
- overhaul `frontenis.html` with Firestore integration
- add forms to register pairs and matches
- compute statistics per pair using Firebase
- link to the tournament page from navigation menus

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687015e93e84832597819ec9d176bdf0