### PR TITLE
Implement category filtering and modal forms

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -9,6 +9,10 @@
 </head>
 <body class="bg-gray-50 p-4 max-w-2xl mx-auto">
     <h1 class="text-2xl font-bold text-center mb-6">Administrador Torneo Frontenis ISSEA</h1>
+    <div class="flex justify-center mb-6 space-x-2">
+        <button id="tabPrimera" data-category="Primera" class="px-4 py-2 bg-blue-600 text-white rounded">Primera</button>
+        <button id="tabSegunda" data-category="Segunda" class="px-4 py-2 bg-gray-200 rounded">Segunda</button>
+    </div>
 
     <section id="infoSection" class="mb-10">
         <h2 class="text-xl font-semibold mb-2">Información del Torneo</h2>
@@ -20,30 +24,46 @@
 
     <section id="playerSection" class="mb-10">
         <h2 class="text-xl font-semibold mb-2">Cédula de Jugador</h2>
-        <form id="playerForm" class="grid grid-cols-1 gap-2">
-            <input id="playerName" placeholder="Nombre" class="border p-2 rounded" required />
-            <select id="playerCategory" class="border p-2 rounded" required>
-                <option value="">Categoría</option>
-                <option value="Primera">Primera</option>
-                <option value="Segunda">Segunda</option>
-            </select>
-            <input id="playerPhone" placeholder="Teléfono (XXX) XXX XXXX" pattern="\(\d{3}\) \d{3} \d{4}" class="border p-2 rounded" required />
-            <input id="playerAdscripcion" placeholder="Adscripción" class="border p-2 rounded" />
-            <input id="playerTurno" placeholder="Turno" class="border p-2 rounded" />
-            <input id="playerBase" placeholder="Tipo de base" class="border p-2 rounded" />
-            <input id="playerTalla" placeholder="Talla de uniforme" class="border p-2 rounded" />
-            <button type="submit" class="bg-blue-600 text-white rounded p-2">Registrar</button>
-        </form>
+        <button id="openPlayerModal" class="bg-blue-600 text-white rounded p-2 mb-2">Añadir Jugador</button>
+        <div id="playerModal" class="hidden fixed inset-0 flex items-center justify-center bg-black bg-opacity-60">
+            <div class="bg-white rounded-lg shadow-2xl p-4 w-80">
+                <form id="playerForm" class="grid grid-cols-1 gap-2">
+                    <input id="playerName" placeholder="Nombre" class="border p-2 rounded" required />
+                    <select id="playerCategory" class="border p-2 rounded" required>
+                        <option value="">Categoría</option>
+                        <option value="Primera">Primera</option>
+                        <option value="Segunda">Segunda</option>
+                    </select>
+                    <input id="playerPhone" placeholder="Teléfono (XXX) XXX XXXX" pattern="\(\d{3}\) \d{3} \d{4}" class="border p-2 rounded" required />
+                    <input id="playerAdscripcion" placeholder="Adscripción" class="border p-2 rounded" />
+                    <input id="playerTurno" placeholder="Turno" class="border p-2 rounded" />
+                    <input id="playerBase" placeholder="Tipo de base" class="border p-2 rounded" />
+                    <input id="playerTalla" placeholder="Talla de uniforme" class="border p-2 rounded" />
+                    <div class="flex justify-end space-x-2">
+                        <button type="button" id="closePlayerModal" class="px-3 py-1 rounded border">Cancelar</button>
+                        <button type="submit" class="bg-blue-600 text-white rounded px-3 py-1">Registrar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
         <ul id="playerList" class="mt-4 space-y-1 text-sm"></ul>
     </section>
 
     <section id="pairSection" class="mb-10">
         <h2 class="text-xl font-semibold mb-2">Agregar Pareja</h2>
-        <form id="pairForm" class="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-4">
-            <input id="zagueroName" placeholder="Zaguero" class="border p-2 rounded" />
-            <input id="delanteroName" placeholder="Delantero" class="border p-2 rounded" />
-            <button type="submit" class="bg-blue-500 text-white rounded p-2">Agregar</button>
-        </form>
+        <button id="openPairModal" class="bg-blue-500 text-white rounded p-2 mb-2">Añadir Pareja</button>
+        <div id="pairModal" class="hidden fixed inset-0 flex items-center justify-center bg-black bg-opacity-60">
+            <div class="bg-white rounded-lg shadow-2xl p-4 w-80">
+                <form id="pairForm" class="grid grid-cols-1 gap-2">
+                    <select id="zagueroSelect" class="border p-2 rounded"></select>
+                    <select id="delanteroSelect" class="border p-2 rounded"></select>
+                    <div class="flex justify-end space-x-2">
+                        <button type="button" id="closePairModal" class="px-3 py-1 rounded border">Cancelar</button>
+                        <button type="submit" class="bg-blue-600 text-white rounded px-3 py-1">Guardar</button>
+                    </div>
+                </form>
+            </div>
+        </div>
         <ul id="pairList" class="mt-4 space-y-1 text-sm"></ul>
     </section>
 
@@ -107,8 +127,11 @@ const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
 const pairForm = document.getElementById('pairForm');
-const zagueroInput = document.getElementById('zagueroName');
-const delanteroInput = document.getElementById('delanteroName');
+const zagueroSelect = document.getElementById('zagueroSelect');
+const delanteroSelect = document.getElementById('delanteroSelect');
+const pairModal = document.getElementById('pairModal');
+const openPairModalBtn = document.getElementById('openPairModal');
+const closePairModalBtn = document.getElementById('closePairModal');
 const pairList = document.getElementById('pairList');
 const pairASelect = document.getElementById('pairA');
 const pairBSelect = document.getElementById('pairB');
@@ -117,7 +140,13 @@ const statsBody = document.getElementById('statsBody');
 const historyList = document.getElementById('historyList');
 const eliminationBracket = document.getElementById('eliminationBracket');
 const playerForm = document.getElementById('playerForm');
+const playerModal = document.getElementById('playerModal');
+const openPlayerModalBtn = document.getElementById('openPlayerModal');
+const closePlayerModalBtn = document.getElementById('closePlayerModal');
 const playerList = document.getElementById('playerList');
+const categoryTabs = document.querySelectorAll('[data-category]');
+
+let currentCategory = 'Primera';
 
 let currentPairs = [];
 let currentMatches = [];
@@ -125,6 +154,60 @@ let currentPlayers = [];
 let editingPairId = null;
 let editingMatchId = null;
 let editingPlayerId = null;
+
+openPlayerModalBtn.onclick = () => {
+    playerForm.reset();
+    playerModal.classList.remove('hidden');
+};
+closePlayerModalBtn.onclick = () => playerModal.classList.add('hidden');
+
+openPairModalBtn.onclick = () => {
+    fillPlayerSelects();
+    pairForm.reset();
+    pairModal.classList.remove('hidden');
+};
+closePairModalBtn.onclick = () => pairModal.classList.add('hidden');
+
+categoryTabs.forEach(t => {
+    t.addEventListener('click', () => {
+        currentCategory = t.dataset.category;
+        updateTabStyles();
+        refreshUI();
+    });
+});
+
+function updateTabStyles() {
+    categoryTabs.forEach(t => {
+        if (t.dataset.category === currentCategory) {
+            t.classList.add('bg-blue-600','text-white');
+            t.classList.remove('bg-gray-200');
+        } else {
+            t.classList.remove('bg-blue-600','text-white');
+            t.classList.add('bg-gray-200');
+        }
+    });
+}
+
+function fillPlayerSelects() {
+    [zagueroSelect, delanteroSelect].forEach(sel => {
+        sel.innerHTML = '<option value="">Jugador</option>';
+        currentPlayers.filter(p => p.category === currentCategory).forEach(p => {
+            const opt = document.createElement('option');
+            opt.value = p.name;
+            opt.textContent = p.name;
+            sel.appendChild(opt);
+        });
+    });
+}
+
+function refreshUI() {
+    const pairs = currentPairs.filter(p => p.category === currentCategory);
+    const matches = currentMatches.filter(m => m.category === currentCategory);
+    renderPairs(pairs);
+    renderStats(computeStats(pairs, matches.filter(m => (m.stage || 'RR') === 'RR')));
+    renderHistory(pairs, matches);
+    renderElimination(pairs, matches);
+}
 
 playerForm.onsubmit = async e => {
     e.preventDefault();
@@ -145,20 +228,23 @@ playerForm.onsubmit = async e => {
         await addDoc(collection(db, 'players'), data);
     }
     playerForm.reset();
+    playerModal.classList.add('hidden');
 };
 
 pairForm.onsubmit = async e => {
     e.preventDefault();
-    const zaguero = zagueroInput.value.trim();
-    const delantero = delanteroInput.value.trim();
+    const zaguero = zagueroSelect.value;
+    const delantero = delanteroSelect.value;
     if (!zaguero || !delantero) return;
+    const data = { zaguero, delantero, category: currentCategory };
     if (editingPairId) {
-        await updateDoc(doc(db, 'pairs', editingPairId), { zaguero, delantero });
+        await updateDoc(doc(db, 'pairs', editingPairId), data);
         editingPairId = null;
     } else {
-        await addDoc(collection(db, 'pairs'), { zaguero, delantero });
+        await addDoc(collection(db, 'pairs'), data);
     }
     pairForm.reset();
+    pairModal.classList.add('hidden');
 };
 
 matchForm.onsubmit = async e => {
@@ -169,11 +255,12 @@ matchForm.onsubmit = async e => {
     const scoreB = parseInt(document.getElementById('scoreB').value) || 0;
     if (!pairA || !pairB || pairA === pairB) return;
     const stage = matchForm.dataset.stage || 'RR';
+    const data = { pairA, pairB, scoreA, scoreB, stage, category: currentCategory, ts: Date.now() };
     if (editingMatchId) {
-        await updateDoc(doc(db, 'matches', editingMatchId), { pairA, pairB, scoreA, scoreB, stage });
+        await updateDoc(doc(db, 'matches', editingMatchId), data);
         editingMatchId = null;
     } else {
-        await addDoc(collection(db, 'matches'), { pairA, pairB, scoreA, scoreB, stage, ts: Date.now() });
+        await addDoc(collection(db, 'matches'), data);
     }
     matchForm.reset();
 };
@@ -210,9 +297,11 @@ pairList.onclick = async e => {
         const id = e.target.dataset.edit;
         const pair = currentPairs.find(p => p.id === id);
         if (pair) {
-            zagueroInput.value = pair.zaguero;
-            delanteroInput.value = pair.delantero;
+            fillPlayerSelects();
+            zagueroSelect.value = pair.zaguero;
+            delanteroSelect.value = pair.delantero;
             editingPairId = id;
+            pairModal.classList.remove('hidden');
         }
     } else if (e.target.dataset.del) {
         const id = e.target.dataset.del;
@@ -235,6 +324,7 @@ playerList.onclick = async e => {
             document.getElementById('playerBase').value = player.base;
             document.getElementById('playerTalla').value = player.talla;
             editingPlayerId = id;
+            playerModal.classList.remove('hidden');
         }
     } else if (e.target.closest('button')?.dataset.del) {
         const id = e.target.closest('button').dataset.del;
@@ -436,16 +526,14 @@ async function loadData() {
     currentPairs = pairs;
     currentMatches = matches;
     currentPlayers = players;
-    renderPairs(pairs);
     renderPlayers(players);
-    renderStats(computeStats(pairs, matches.filter(m => (m.stage || 'RR') === 'RR')));
-    renderHistory(pairs, matches);
-    renderElimination(pairs, matches);
+    refreshUI();
 }
 
 onSnapshot(collection(db, 'pairs'), loadData);
 onSnapshot(collection(db, 'matches'), loadData);
 onSnapshot(collection(db, 'players'), loadData);
+updateTabStyles();
 loadData();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add category tabs for Primera and Segunda
- replace inline forms with modals for players and pairs
- filter pairs, matches and stats by selected category
- update match and pair records with category field

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687027404fbc83259094d2c97df80638