### PR TITLE
Add Round Robin scheduling

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -80,7 +80,11 @@
 
     <section id="matchSection" class="mb-10">
         <h2 class="text-xl font-semibold mb-2">Registrar Partido</h2>
+        <div class="mb-2">
+            <button id="generateSchedule" class="bg-blue-600 text-white rounded p-2">Generar Calendario</button>
+        </div>
         <form id="matchForm" class="grid grid-cols-2 gap-2 items-center">
+            <select id="daySelect" class="border p-2 rounded"></select>
             <select id="courtSelect" class="border p-2 rounded">
                 <option value="">Cancha</option>
                 <option value="1">Cancha 1</option>
@@ -145,6 +149,8 @@ const pairBSelect = document.getElementById('pairB');
 const matchForm = document.getElementById('matchForm');
 const courtSelect = document.getElementById('courtSelect');
 const timeSelect = document.getElementById('timeSelect');
+const daySelect = document.getElementById('daySelect');
+const generateScheduleBtn = document.getElementById('generateSchedule');
 const statsBody = document.getElementById('statsBody');
 const historyList = document.getElementById('historyList');
 const eliminationBracket = document.getElementById('eliminationBracket');
@@ -164,6 +170,21 @@ let editingPairId = null;
 let editingMatchId = null;
 let editingPlayerId = null;
 
+const availableDays = ['2025-09-09','2025-09-16','2025-09-23','2025-09-30'];
+const courts = ['1','2'];
+const timeSlots = [];
+for (let h=16; h<20; h++) { timeSlots.push(`${h}:00`); timeSlots.push(`${h}:30`); }
+
+function fillDayOptions() {
+    daySelect.innerHTML = '<option value="">Día</option>';
+    availableDays.forEach(d => {
+        const opt = document.createElement('option');
+        opt.value = d;
+        opt.textContent = d;
+        daySelect.appendChild(opt);
+    });
+}
+
 openPlayerModalBtn.onclick = () => {
     playerForm.reset();
     playerModal.classList.remove('hidden');
@@ -171,6 +192,8 @@ openPlayerModalBtn.onclick = () => {
 closePlayerModalBtn.onclick = () => playerModal.classList.add('hidden');
 
 courtSelect.onchange = fillTimeOptions;
+daySelect.onchange = fillTimeOptions;
+generateScheduleBtn.onclick = generateRoundRobin;
 
 openPairModalBtn.onclick = () => {
     fillPlayerSelects();
@@ -219,16 +242,12 @@ function formatTime(t) {
 }
 
 function fillTimeOptions() {
-    const times = [];
-    for (let h = 16; h < 20; h++) {
-        times.push(`${h}:00`);
-        times.push(`${h}:30`);
-    }
     timeSelect.innerHTML = '<option value="">Horario</option>';
     const selectedCourt = courtSelect.value;
-    const taken = currentMatches.filter(m => m.court === selectedCourt && (!editingMatchId || m.id !== editingMatchId)).map(m => m.time);
-    times.forEach(t => {
-        if (selectedCourt && taken.includes(t)) return;
+    const selectedDay = daySelect.value;
+    const taken = currentMatches.filter(m => m.court === selectedCourt && m.day === selectedDay && (!editingMatchId || m.id !== editingMatchId)).map(m => m.time);
+    timeSlots.forEach(t => {
+        if (selectedCourt && selectedDay && taken.includes(t)) return;
         const opt = document.createElement('option');
         opt.value = t;
         opt.textContent = formatTime(t);
@@ -236,7 +255,7 @@ function fillTimeOptions() {
     });
     if (editingMatchId) {
         const match = currentMatches.find(m => m.id === editingMatchId);
-        if (match && match.court === selectedCourt && !times.includes(match.time)) {
+        if (match && match.court === selectedCourt && match.day === selectedDay && !timeSlots.includes(match.time)) {
             const opt = document.createElement('option');
             opt.value = match.time;
             opt.textContent = formatTime(match.time);
@@ -252,6 +271,7 @@ function refreshUI() {
     renderStats(computeStats(pairs, matches.filter(m => (m.stage || 'RR') === 'RR')));
     renderHistory(pairs, matches);
     renderElimination(pairs, matches);
+    fillDayOptions();
     fillTimeOptions();
 }
 
@@ -297,15 +317,16 @@ matchForm.onsubmit = async e => {
     e.preventDefault();
     const pairA = pairASelect.value;
     const pairB = pairBSelect.value;
+    const day = daySelect.value;
     const court = courtSelect.value;
     const time = timeSelect.value;
     const scoreA = parseInt(document.getElementById('scoreA').value) || 0;
     const scoreB = parseInt(document.getElementById('scoreB').value) || 0;
-    if (!pairA || !pairB || pairA === pairB || !court || !time) return;
-    const conflict = currentMatches.some(m => m.category === currentCategory && m.court === court && m.time === time && m.id !== editingMatchId);
+    if (!pairA || !pairB || pairA === pairB || !court || !time || !day) return;
+    const conflict = currentMatches.some(m => m.category === currentCategory && m.court === court && m.day === day && m.time === time && m.id !== editingMatchId);
     if (conflict) { alert('Horario no disponible'); return; }
     const stage = matchForm.dataset.stage || 'RR';
-    const data = { pairA, pairB, scoreA, scoreB, stage, category: currentCategory, court, time, ts: Date.now() };
+    const data = { pairA, pairB, scoreA, scoreB, stage, category: currentCategory, court, time, day, ts: Date.now() };
     if (editingMatchId) {
         await updateDoc(doc(db, 'matches', editingMatchId), data);
         editingMatchId = null;
@@ -417,7 +438,7 @@ function renderHistory(pairs, matches) {
     matches.forEach(m => {
         const stage = m.stage || 'RR';
         const li = document.createElement('li');
-        li.innerHTML = `${stage}: ${map[m.pairA] || '?'} ${m.scoreA}-${m.scoreB} ${map[m.pairB] || '?'} (C${m.court || '?'} ${m.time ? formatTime(m.time) : ''}) <button data-edit="${m.id}" class="text-blue-600"><i class="ti ti-pencil"></i></button> <button data-del="${m.id}" class="text-red-600"><i class="ti ti-trash"></i></button>`;
+        li.innerHTML = `${stage}: ${map[m.pairA] || '?'} ${m.scoreA}-${m.scoreB} ${map[m.pairB] || '?'} (${m.day || '?'} C${m.court || '?'} ${m.time ? formatTime(m.time) : ''}) <button data-edit="${m.id}" class="text-blue-600"><i class="ti ti-pencil"></i></button> <button data-del="${m.id}" class="text-red-600"><i class="ti ti-trash"></i></button>`;
         historyList.appendChild(li);
     });
 }
@@ -431,6 +452,7 @@ historyList.onclick = async e => {
             pairBSelect.value = match.pairB;
             document.getElementById('scoreA').value = match.scoreA;
             document.getElementById('scoreB').value = match.scoreB;
+            daySelect.value = match.day || '';
             courtSelect.value = match.court || '';
             fillTimeOptions();
             timeSelect.value = match.time || '';
@@ -582,6 +604,38 @@ async function loadData() {
     currentPlayers = players;
     renderPlayers(players);
     refreshUI();
+}
+
+async function generateRoundRobin() {
+    const pairs = currentPairs.filter(p => p.category === currentCategory);
+    if (pairs.length < 2) { alert('Se requieren al menos dos parejas'); return; }
+    const existing = currentMatches.filter(m => m.category === currentCategory && (m.stage || 'RR') === 'RR');
+    if (existing.length && !confirm('Ya existe un rol. ¿Deseas reemplazarlo?')) return;
+    for (const m of existing) { await deleteDoc(doc(db,'matches', m.id)); }
+    let ids = pairs.map(p => p.id);
+    if (ids.length % 2 === 1) ids.push(null);
+    const numRounds = ids.length - 1;
+    const half = ids.length / 2;
+    let arr = ids.slice();
+    let schedule = [];
+    for (let r=0; r<numRounds; r++) {
+        const day = availableDays[r % availableDays.length];
+        let timeIdx = 0, courtIdx = 0;
+        for (let i=0; i<half; i++) {
+            const a = arr[i];
+            const b = arr[arr.length-1-i];
+            if (a && b) {
+                const time = timeSlots[timeIdx];
+                const court = courts[courtIdx];
+                schedule.push({pairA:a, pairB:b, day, court, time, scoreA:0, scoreB:0, stage:'RR', category:currentCategory, ts:Date.now()});
+                courtIdx++;
+                if (courtIdx >= courts.length) { courtIdx = 0; timeIdx++; }
+            }
+        }
+        arr.splice(1,0,arr.pop());
+    }
+    for (const m of schedule) { await addDoc(collection(db,'matches'), m); }
+    alert('Rol generado');
 }
 
 async function exportDatabase() {


### PR DESCRIPTION
## Summary
- add UI to generate match calendar
- implement round robin schedule generator
- allow picking day when scheduling matches

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6870478c476483259c4f0c440ab8ce9e