### PR TITLE
Update tournament admin UI

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -107,20 +107,24 @@
         <div id="matchModal" class="hidden fixed inset-0 flex items-center justify-center bg-black bg-opacity-60">
             <div class="bg-white rounded-lg shadow-2xl p-4 w-80">
                 <h3 class="text-lg font-semibold mb-2">Registro de Partido</h3>
-                <form id="matchForm" class="grid grid-cols-2 gap-2 items-center">
-                    <select id="daySelect" class="border p-2 rounded"></select>
-                    <select id="courtSelect" class="border p-2 rounded">
-                        <option value="">Cancha</option>
-                        <option value="1">Cancha 1</option>
-                        <option value="2">Cancha 2</option>
-                    </select>
-                    <select id="timeSelect" class="border p-2 rounded"></select>
-                    <select id="pairA" class="border p-2 rounded"></select>
-                    <input id="scoreA" type="number" min="0" class="border p-2 rounded" />
-                    <span class="col-span-2 text-center">vs</span>
-                    <select id="pairB" class="border p-2 rounded"></select>
-                    <input id="scoreB" type="number" min="0" class="border p-2 rounded" />
-                    <div class="col-span-2 flex justify-end space-x-2">
+                <form id="matchForm" class="space-y-3">
+                    <div class="grid grid-cols-3 gap-2">
+                        <select id="daySelect" class="border p-2 rounded"></select>
+                        <select id="timeSelect" class="border p-2 rounded"></select>
+                        <select id="courtSelect" class="border p-2 rounded">
+                            <option value="">Cancha</option>
+                            <option value="1">Cancha 1</option>
+                            <option value="2">Cancha 2</option>
+                        </select>
+                    </div>
+                    <div class="grid grid-cols-6 gap-2 items-center">
+                        <select id="pairA" class="border p-2 rounded col-span-2"></select>
+                        <input id="scoreA" type="number" min="0" class="border p-2 rounded" />
+                        <span class="text-center">vs</span>
+                        <input id="scoreB" type="number" min="0" class="border p-2 rounded" />
+                        <select id="pairB" class="border p-2 rounded col-span-2"></select>
+                    </div>
+                    <div class="flex justify-end space-x-2">
                         <button type="button" id="closeMatchModal" class="px-3 py-1 rounded border">Cancelar</button>
                         <button type="submit" class="bg-green-600 text-white rounded px-3 py-1">Guardar</button>
                     </div>
@@ -152,6 +156,11 @@
                 <tbody id="statsBody"></tbody>
             </table>
         </div>
+    </section>
+
+    <section id="resultsSection" class="glass-card p-4 mb-10">
+        <h2 class="text-xl font-semibold mb-2">Resultados Finales</h2>
+        <div id="finalResults" class="space-y-1 text-sm"></div>
     </section>
 
 <script type="module">
@@ -344,6 +353,7 @@ function refreshUI() {
     renderHistory(pairs, matches);
     maybeGenerateFinals(pairs, matches);
     renderElimination(pairs, matches);
+    renderFinalResults(pairs, matches);
     fillDayOptions();
     fillTimeOptions();
 }
@@ -609,38 +619,37 @@ function renderElimination(pairs, matches) {
         return;
     }
 
-    const createForm = (label, aId, bId, stage, existing) => {
+    const createForm = (aId, bId, stage, existing) => {
         const form = document.createElement('form');
-        form.className = 'grid grid-cols-2 gap-2 items-center mb-4';
+        form.className = 'space-y-2';
         form.dataset.stage = stage;
         form.innerHTML = `
-            <span class="col-span-2 font-semibold">${label}</span>
-            <select class="border p-2 rounded" name="a"></select>
-            <input class="border p-2 rounded" name="sa" type="number" min="0" />
-            <span class="col-span-2 text-center">vs</span>
-            <select class="border p-2 rounded" name="b"></select>
-            <input class="border p-2 rounded" name="sb" type="number" min="0" />
-            <button type="submit" class="bg-green-600 text-white rounded p-2 col-span-2">Guardar</button>`;
-        const selA = form.querySelector('select[name="a"]');
-        const selB = form.querySelector('select[name="b"]');
-        [aId,bId].forEach((id,idx) => {
-            const opt = document.createElement('option');
-            opt.value = id;
-            opt.textContent = map[id];
-            if (idx===0) selA.appendChild(opt); else selB.appendChild(opt);
-        });
+            <div class="grid grid-cols-2 gap-2 items-center">
+                <span>${map[aId]}</span>
+                <input class="border p-2 rounded" name="sa" type="number" min="0" />
+            </div>
+            <div class="text-center font-semibold">vs</div>
+            <div class="grid grid-cols-2 gap-2 items-center">
+                <span>${map[bId]}</span>
+                <input class="border p-2 rounded" name="sb" type="number" min="0" />
+            </div>
+            <input type="hidden" name="a" value="${aId}">
+            <input type="hidden" name="b" value="${bId}">
+            <div class="flex justify-end">
+                <button type="submit" class="bg-green-600 text-white rounded p-2">Guardar</button>
+            </div>`;
+        const inputA = form.querySelector('input[name="sa"]');
+        const inputB = form.querySelector('input[name="sb"]');
         if (existing) {
-            selA.value = existing.pairA;
-            selB.value = existing.pairB;
-            form.querySelector('input[name="sa"]').value = existing.scoreA;
-            form.querySelector('input[name="sb"]').value = existing.scoreB;
+            inputA.value = existing.scoreA;
+            inputB.value = existing.scoreB;
         }
         form.onsubmit = async ev => {
             ev.preventDefault();
-            const pairA = selA.value;
-            const pairB = selB.value;
-            const scoreA = parseInt(form.querySelector('input[name="sa"]').value)||0;
-            const scoreB = parseInt(form.querySelector('input[name="sb"]').value)||0;
+            const scoreA = parseInt(inputA.value)||0;
+            const scoreB = parseInt(inputB.value)||0;
+            const pairA = aId;
+            const pairB = bId;
             const data = { pairA, pairB, scoreA, scoreB, stage, ts:Date.now() };
             if (existing) {
                 await updateDoc(doc(db,'matches', existing.id), data);
@@ -652,8 +661,44 @@ function renderElimination(pairs, matches) {
         return form;
     };
 
-    eliminationBracket.appendChild(createForm('Final', top4[0].id, top4[1].id, 'F', finalMatch));
-    eliminationBracket.appendChild(createForm('Tercer Lugar', top4[2].id, top4[3].id, '3P', thirdMatch));
+    const finalCard = document.createElement('details');
+    finalCard.className = 'glass-card p-4 mb-4';
+    const finalSum = document.createElement('summary');
+    finalSum.className = 'font-semibold cursor-pointer';
+    finalSum.textContent = 'Final';
+    finalCard.appendChild(finalSum);
+    finalCard.appendChild(createForm(top4[0].id, top4[1].id, 'F', finalMatch));
+
+    const thirdCard = document.createElement('details');
+    thirdCard.className = 'glass-card p-4 mb-4';
+    const thirdSum = document.createElement('summary');
+    thirdSum.className = 'font-semibold cursor-pointer';
+    thirdSum.textContent = 'Tercer Lugar';
+    thirdCard.appendChild(thirdSum);
+    thirdCard.appendChild(createForm(top4[2].id, top4[3].id, '3P', thirdMatch));
+
+    eliminationBracket.appendChild(finalCard);
+    eliminationBracket.appendChild(thirdCard);
+}
+
+function renderFinalResults(pairs, matches) {
+    const container = document.getElementById('finalResults');
+    const map = Object.fromEntries(pairs.map(p => [p.id, `${p.zaguero} / ${p.delantero}`]));
+    const finalMatch = matches.find(m => m.stage === 'F');
+    const thirdMatch = matches.find(m => m.stage === '3P');
+    container.innerHTML = '';
+    if (!finalMatch || !thirdMatch) {
+        container.textContent = 'Resultados pendientes';
+        return;
+    }
+    const first = finalMatch.scoreA > finalMatch.scoreB ? finalMatch.pairA : finalMatch.pairB;
+    const second = finalMatch.scoreA > finalMatch.scoreB ? finalMatch.pairB : finalMatch.pairA;
+    const third = thirdMatch.scoreA > thirdMatch.scoreB ? thirdMatch.pairA : thirdMatch.pairB;
+    [{label:'Primer Lugar', id:first}, {label:'Segundo Lugar', id:second}, {label:'Tercer Lugar', id:third}].forEach(r => {
+        const div = document.createElement('div');
+        div.textContent = `${r.label}: ${map[r.id] || '?'}`;
+        container.appendChild(div);
+    });
 }
 
 async function loadData() {


### PR DESCRIPTION
## Summary
- redesign match registration form for better UX
- show final results section with winners
- display elimination matches with fixed pairs
- make final and third place collapsible

## Testing
- `npx --yes htmlhint frontenis.html`

------
https://chatgpt.com/codex/tasks/task_e_687065b9bf78832599e98ce86b4969d9