### PR TITLE
Add match status with forfeit handling

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -136,6 +136,13 @@
                         <input id="scoreB" type="number" min="0" class="border p-2 rounded" />
                         <select id="pairB" class="border p-2 rounded col-span-2"></select>
                     </div>
+                    <div>
+                        <select id="statusSelect" class="border p-2 rounded w-full mt-2">
+                            <option value="Pendiente">Pendiente</option>
+                            <option value="NoA">No Jugado - gana Pareja A</option>
+                            <option value="NoB">No Jugado - gana Pareja B</option>
+                        </select>
+                    </div>
                     <div class="flex justify-end space-x-2">
                         <button type="button" id="closeMatchModal" class="px-3 py-1 rounded border">Cancelar</button>
                         <button type="submit" class="bg-green-600 text-white rounded px-3 py-1">Guardar</button>
@@ -209,6 +216,7 @@ const matchForm = document.getElementById('matchForm');
 const matchModal = document.getElementById('matchModal');
 const openMatchModalBtn = document.getElementById('openMatchModal');
 const closeMatchModalBtn = document.getElementById('closeMatchModal');
+const statusSelect = document.getElementById('statusSelect');
 const courtSelect = document.getElementById('courtSelect');
 const timeSelect = document.getElementById('timeSelect');
 const daySelect = document.getElementById('daySelect');
@@ -280,6 +288,7 @@ openMatchModalBtn.onclick = () => {
     matchForm.reset();
     matchForm.dataset.stage = 'RR';
     editingMatchId = null;
+    statusSelect.value = 'Pendiente';
     fillDayOptions();
     fillTimeOptions();
     matchModal.classList.remove('hidden');
@@ -421,13 +430,18 @@ matchForm.onsubmit = async e => {
     const day = daySelect.value;
     const court = courtSelect.value;
     const time = timeSelect.value;
-    const scoreA = parseInt(document.getElementById('scoreA').value) || 0;
-    const scoreB = parseInt(document.getElementById('scoreB').value) || 0;
+    let scoreA = parseInt(document.getElementById('scoreA').value) || 0;
+    let scoreB = parseInt(document.getElementById('scoreB').value) || 0;
     if (!pairA || !pairB || pairA === pairB || !court || !time || !day) return;
     const conflict = currentMatches.some(m => m.court === court && m.day === day && m.time === time && m.id !== editingMatchId);
     if (conflict) { alert('Horario no disponible'); return; }
     const stage = matchForm.dataset.stage || 'RR';
-    const data = { pairA, pairB, scoreA, scoreB, stage, category: currentCategory, court, time, day, ts: Date.now() };
+    let status = statusSelect.value;
+    if (status === 'NoA') { status = 'No Jugado'; scoreA = 1; scoreB = 0; }
+    else if (status === 'NoB') { status = 'No Jugado'; scoreA = 0; scoreB = 1; }
+    else if (scoreA !== 0 || scoreB !== 0) { status = 'Finalizado'; }
+    else { status = 'Pendiente'; }
+    const data = { pairA, pairB, scoreA, scoreB, stage, category: currentCategory, court, time, day, ts: Date.now(), status };
     if (editingMatchId) {
         await updateDoc(doc(db, 'matches', editingMatchId), data);
         editingMatchId = null;
@@ -435,6 +449,7 @@ matchForm.onsubmit = async e => {
         await addDoc(collection(db, 'matches'), data);
     }
     matchForm.reset();
+    statusSelect.value = 'Pendiente';
     fillTimeOptions();
     matchModal.classList.add('hidden');
 };
@@ -523,11 +538,14 @@ function computeStats(pairs, matches) {
         const a = stats[m.pairA];
         const b = stats[m.pairB];
         if (!a || !b) return;
-        a.jj++; b.jj++;
-        a.pf += m.scoreA; a.pc += m.scoreB;
-        b.pf += m.scoreB; b.pc += m.scoreA;
-        if (m.scoreA > m.scoreB) { a.jg++; b.jp++; }
-        else if (m.scoreB > m.scoreA) { b.jg++; a.jp++; }
+        const st = m.status || ((m.scoreA || m.scoreB) ? 'Finalizado' : 'Pendiente');
+        if (st === 'Finalizado' || st === 'No Jugado') {
+            a.jj++; b.jj++;
+            a.pf += m.scoreA; a.pc += m.scoreB;
+            b.pf += m.scoreB; b.pc += m.scoreA;
+            if (m.scoreA > m.scoreB) { a.jg++; b.jp++; }
+            else if (m.scoreB > m.scoreA) { b.jg++; a.jp++; }
+        }
     });
     return Object.values(stats);
 }
@@ -550,10 +568,10 @@ async function maybeGenerateFinals(pairs, matches) {
     const day = fmt(last);
     const ts = Date.now();
     if (!finalExists) {
-        await addDoc(collection(db,'matches'), {pairA:top4[0].id, pairB:top4[1].id, day, court:courts[0], time:timeSlots[0], scoreA:0, scoreB:0, stage:'F', match:'F', category:currentCategory, ts});
+        await addDoc(collection(db,'matches'), {pairA:top4[0].id, pairB:top4[1].id, day, court:courts[0], time:timeSlots[0], scoreA:0, scoreB:0, stage:'F', match:'F', category:currentCategory, ts, status:'Pendiente'});
     }
     if (!thirdExists) {
-        await addDoc(collection(db,'matches'), {pairA:top4[2].id, pairB:top4[3].id, day, court:courts[1]||courts[0], time:timeSlots[0], scoreA:0, scoreB:0, stage:'3P', match:'3P', category:currentCategory, ts});
+        await addDoc(collection(db,'matches'), {pairA:top4[2].id, pairB:top4[3].id, day, court:courts[1]||courts[0], time:timeSlots[0], scoreA:0, scoreB:0, stage:'3P', match:'3P', category:currentCategory, ts, status:'Pendiente'});
     }
 }
 
@@ -589,7 +607,7 @@ function renderHistory(pairs, matches) {
         const stage = m.stage || 'RR';
         const li = document.createElement('li');
         li.className = 'ml-4';
-        li.innerHTML = `${stage}: ${map[m.pairA] || '?'} ${m.scoreA}-${m.scoreB} ${map[m.pairB] || '?'} <button data-edit="${m.id}" class="text-blue-600"><i class="ti ti-pencil"></i></button> <button data-del="${m.id}" class="text-red-600"><i class="ti ti-trash"></i></button>`;
+        li.innerHTML = `${stage}: ${map[m.pairA] || '?'} ${m.scoreA}-${m.scoreB} ${map[m.pairB] || '?'} (${m.status || 'Pendiente'}) <button data-edit="${m.id}" class="text-blue-600"><i class="ti ti-pencil"></i></button> <button data-del="${m.id}" class="text-red-600"><i class="ti ti-trash"></i></button>`;
         historyList.appendChild(li);
     });
 }
@@ -607,6 +625,13 @@ historyList.onclick = async e => {
             courtSelect.value = match.court || '';
             fillTimeOptions();
             timeSelect.value = match.time || '';
+            if (match.status === 'No Jugado') {
+                if (match.scoreA === 1 && match.scoreB === 0) statusSelect.value = 'NoA';
+                else if (match.scoreB === 1 && match.scoreA === 0) statusSelect.value = 'NoB';
+                else statusSelect.value = 'Pendiente';
+            } else {
+                statusSelect.value = match.status || 'Pendiente';
+            }
             matchForm.dataset.stage = match.stage || 'RR';
             editingMatchId = id;
             matchModal.classList.remove('hidden');
@@ -665,7 +690,7 @@ function renderElimination(pairs, matches) {
             const scoreB = parseInt(inputB.value)||0;
             const pairA = aId;
             const pairB = bId;
-            const data = { pairA, pairB, scoreA, scoreB, stage, ts:Date.now() };
+            const data = { pairA, pairB, scoreA, scoreB, stage, ts:Date.now(), status:'Finalizado' };
             if (existing) {
                 await updateDoc(doc(db,'matches', existing.id), data);
             } else {
@@ -761,7 +786,7 @@ async function generateRoundRobin() {
         const slot = idx % totalSlotsPerDay;
         const court = courts[slot % courts.length];
         const time = timeSlots[Math.floor(slot / courts.length)];
-        Object.assign(m, { day, court, time, scoreA: 0, scoreB: 0, stage: 'RR', ts: Date.now() });
+        Object.assign(m, { day, court, time, scoreA: 0, scoreB: 0, stage: 'RR', ts: Date.now(), status:'Pendiente' });
     });
 
     for (const m of unscheduled) { await addDoc(collection(db, 'matches'), m); }


### PR DESCRIPTION
## Summary
- introduce match `status` field with UI selector
- compute statistics only for finished matches
- mark pending matches on schedule generation and finals
- handle walkovers via status selector

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687070b876c08325b670df9d3004314a