### PR TITLE
Remove button and redesign match modal

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -114,34 +114,36 @@
         <div class="mb-2 space-x-2">
             <button id="generateSchedule" class="bg-blue-600 text-white rounded p-2">Generar Calendario</button>
             <button id="downloadPdf" class="bg-indigo-600 text-white rounded p-2">Calendario PDF</button>
-            <button id="openMatchModal" class="bg-green-600 text-white rounded p-2">Registrar resultado</button>
         </div>
         <div id="matchModal" class="hidden fixed inset-0 flex items-center justify-center bg-black bg-opacity-60">
             <div class="bg-white rounded-lg shadow-2xl p-4 w-80">
                 <h3 class="text-lg font-semibold mb-2">Partido</h3>
                 <form id="matchForm" class="space-y-3">
-                    <div class="grid grid-cols-3 gap-2">
+                    <div class="grid grid-cols-1 gap-2">
+                        <select id="categorySelect" class="border p-2 rounded">
+                            <option value="Primera">Primera</option>
+                            <option value="Segunda">Segunda</option>
+                        </select>
                         <select id="daySelect" class="border p-2 rounded"></select>
-                        <select id="timeSelect" class="border p-2 rounded"></select>
                         <select id="courtSelect" class="border p-2 rounded">
                             <option value="">Cancha</option>
                             <option value="1">Cancha 1</option>
                             <option value="2">Cancha 2</option>
                         </select>
+                        <select id="timeSelect" class="border p-2 rounded"></select>
+                        <select id="statusSelect" class="border p-2 rounded">
+                            <option value="Pendiente">Pendiente</option>
+                            <option value="NoA">No Jugado - gana Pareja A</option>
+                            <option value="NoB">No Jugado - gana Pareja B</option>
+                        </select>
                     </div>
+                    <hr>
                     <div class="grid grid-cols-6 gap-2 items-center">
                         <select id="pairA" class="border p-2 rounded col-span-2"></select>
                         <input id="scoreA" type="number" min="0" class="border p-2 rounded" />
                         <span class="text-center">vs</span>
                         <input id="scoreB" type="number" min="0" class="border p-2 rounded" />
                         <select id="pairB" class="border p-2 rounded col-span-2"></select>
-                    </div>
-                    <div>
-                        <select id="statusSelect" class="border p-2 rounded w-full mt-2">
-                            <option value="Pendiente">Pendiente</option>
-                            <option value="NoA">No Jugado - gana Pareja A</option>
-                            <option value="NoB">No Jugado - gana Pareja B</option>
-                        </select>
                     </div>
                     <div class="flex justify-end space-x-2">
                         <button type="button" id="closeMatchModal" class="px-3 py-1 rounded border">Cancelar</button>
@@ -220,6 +222,7 @@ const statusSelect = document.getElementById('statusSelect');
 const courtSelect = document.getElementById('courtSelect');
 const timeSelect = document.getElementById('timeSelect');
 const daySelect = document.getElementById('daySelect');
+const categorySelect = document.getElementById('categorySelect');
 const generateScheduleBtn = document.getElementById('generateSchedule');
 const downloadPdfBtn = document.getElementById('downloadPdf');
 const statsBody = document.getElementById('statsBody');
@@ -284,15 +287,18 @@ openPairModalBtn.onclick = () => {
 };
 closePairModalBtn.onclick = () => pairModal.classList.add('hidden');
 
-openMatchModalBtn.onclick = () => {
-    matchForm.reset();
-    matchForm.dataset.stage = 'RR';
-    editingMatchId = null;
-    statusSelect.value = 'Pendiente';
-    fillDayOptions();
-    fillTimeOptions();
-    matchModal.classList.remove('hidden');
-};
+if (openMatchModalBtn) {
+    openMatchModalBtn.onclick = () => {
+        matchForm.reset();
+        matchForm.dataset.stage = 'RR';
+        editingMatchId = null;
+        statusSelect.value = 'Pendiente';
+        categorySelect.value = currentCategory;
+        fillDayOptions();
+        fillTimeOptions();
+        matchModal.classList.remove('hidden');
+    };
+}
 closeMatchModalBtn.onclick = () => {
     matchModal.classList.add('hidden');
     editingMatchId = null;
@@ -430,6 +436,7 @@ matchForm.onsubmit = async e => {
     const day = daySelect.value;
     const court = courtSelect.value;
     const time = timeSelect.value;
+    const category = categorySelect.value || currentCategory;
     let scoreA = parseInt(document.getElementById('scoreA').value) || 0;
     let scoreB = parseInt(document.getElementById('scoreB').value) || 0;
     if (!pairA || !pairB || pairA === pairB || !court || !time || !day) return;
@@ -441,7 +448,7 @@ matchForm.onsubmit = async e => {
     else if (status === 'NoB') { status = 'No Jugado'; scoreA = 0; scoreB = 1; }
     else if (scoreA !== 0 || scoreB !== 0) { status = 'Finalizado'; }
     else { status = 'Pendiente'; }
-    const data = { pairA, pairB, scoreA, scoreB, stage, category: currentCategory, court, time, day, ts: Date.now(), status };
+    const data = { pairA, pairB, scoreA, scoreB, stage, category, court, time, day, ts: Date.now(), status };
     if (editingMatchId) {
         await updateDoc(doc(db, 'matches', editingMatchId), data);
         editingMatchId = null;
@@ -621,6 +628,7 @@ historyList.onclick = async e => {
             pairBSelect.value = match.pairB;
             document.getElementById('scoreA').value = match.scoreA;
             document.getElementById('scoreB').value = match.scoreB;
+            categorySelect.value = match.category || currentCategory;
             daySelect.value = match.day || '';
             courtSelect.value = match.court || '';
             fillTimeOptions();


### PR DESCRIPTION
## Summary
- remove `Registrar resultado` button
- restyle match modal to collect category, date, court, time and status before scores
- adjust script to handle new `categorySelect` field and optional open match button

## Testing
- `git diff --color | sed -n '1,120p'`


------
https://chatgpt.com/codex/tasks/task_e_6870768e727c8325ad7ff4d27601d203