### PR TITLE
Fix final results display when matches are pending

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -753,9 +753,10 @@ function renderFinalResults(pairs, matches) {
     const map = Object.fromEntries(pairs.map(p => [p.id, `${p.zaguero} / ${p.delantero}`]));
     const finalMatch = matches.find(m => m.stage === 'F');
     const thirdMatch = matches.find(m => m.stage === '3P');
+    const rrDone = matches.filter(m => (m.stage || 'RR') === 'RR').every(m => m.status === 'Finalizado');
     container.innerHTML = '';
-    if (!finalMatch || !thirdMatch) {
-        container.textContent = 'Resultados pendientes';
+    if (!finalMatch || !thirdMatch || finalMatch.status !== 'Finalizado' || thirdMatch.status !== 'Finalizado' || !rrDone) {
+        container.textContent = 'Pendiente de resultados';
         return;
     }
     const first = finalMatch.scoreA > finalMatch.scoreB ? finalMatch.pairA : finalMatch.pairB;


### PR DESCRIPTION
## Summary
- show "Pendiente de resultados" if any round robin or final match is not finished

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68707e02b1788325ba0accd79b7b8b99