### PR TITLE
Update finals bracket to await RR completion

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -673,7 +673,7 @@ historyBody.onclick = async e => {
 
 function renderElimination(pairs, matches) {
     const rrMatches = matches.filter(m => (m.stage || 'RR') === 'RR');
-    const rrDone = rrMatches.every(m => m.status !== 'Pendiente');
+    const rrDone = rrMatches.every(m => m.status === "Finalizado" || m.status === "No Jugado");
     const stats = computeStats(pairs, rrMatches);
     stats.sort((a,b) => b.jg - a.jg || (b.pf - b.pc) - (a.pf - a.pc));
     const top4 = stats.slice(0,4);
@@ -757,7 +757,7 @@ function renderFinalResults(pairs, matches) {
     const map = Object.fromEntries(pairs.map(p => [p.id, `${p.zaguero} / ${p.delantero}`]));
     const finalMatch = matches.find(m => m.stage === 'F');
     const thirdMatch = matches.find(m => m.stage === '3P');
-    const rrDone = matches.filter(m => (m.stage || 'RR') === 'RR').every(m => m.status === 'Finalizado');
+    const rrDone = matches.filter(m => (m.stage || 'RR') === 'RR').every(m => m.status === 'Finalizado' || m.status === 'No Jugado');
     container.innerHTML = '';
     if (!finalMatch || !thirdMatch || finalMatch.status !== 'Finalizado' || thirdMatch.status !== 'Finalizado' || !rrDone) {
         container.textContent = 'Pendiente de resultados';


### PR DESCRIPTION
## Summary
- ensure finals forms use `Pendiente de Resultados` until round robin matches are finished
- show final results only when all round robin games are marked `Finalizado` or `No Jugado`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870830efd148325ad21d1692cd240b4