### PR TITLE
Add collapsible cards for tournament info

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -109,37 +109,43 @@
             </div>
         </details>
 
-        <h3 class="text-lg font-semibold mt-4">🏁 REGLAMENTO DE JUEGO</h3>
-        <h4 class="font-semibold">Reglas técnicas:</h4>
-        <ul class="list-disc pl-6">
-            <li>Se jugará bajo el reglamento oficial de frontenis olímpico.</li>
-            <li>Cada partido se jugará a un máximo de 3 sets.</li>
-            <li>Se permite calentar 5 minutos antes de cada partido.</li>
-        </ul>
+        <details class="mt-4">
+            <summary class="font-semibold cursor-pointer">🏁 REGLAMENTO DE JUEGO</summary>
+            <div class="space-y-2 mt-2">
+                <h4 class="font-semibold">Reglas técnicas:</h4>
+                <ul class="list-disc pl-6">
+                    <li>Se jugará bajo el reglamento oficial de frontenis olímpico.</li>
+                    <li>Cada partido se jugará a un máximo de 3 sets.</li>
+                    <li>Se permite calentar 5 minutos antes de cada partido.</li>
+                </ul>
 
-        <h4 class="font-semibold">Puntaje:</h4>
-        <ul class="list-disc pl-6">
-            <li>Partido ganado: 1 punto</li>
-            <li>Partido perdido: 0 puntos</li>
-            <li>Partido no jugado por inasistencia: derrota automática con marcador 1-0</li>
-        </ul>
+                <h4 class="font-semibold">Puntaje:</h4>
+                <ul class="list-disc pl-6">
+                    <li>Partido ganado: 1 punto</li>
+                    <li>Partido perdido: 0 puntos</li>
+                    <li>Partido no jugado por inasistencia: derrota automática con marcador 1-0</li>
+                </ul>
 
-        <h4 class="font-semibold">Inasistencias y sanciones:</h4>
-        <ul class="list-disc pl-6">
-            <li>Si una pareja no se presenta pasados 10 minutos del horario establecido, perderá por default.</li>
-            <li>Dos inasistencias consecutivas descalifican automáticamente a la pareja.</li>
-        </ul>
+                <h4 class="font-semibold">Inasistencias y sanciones:</h4>
+                <ul class="list-disc pl-6">
+                    <li>Si una pareja no se presenta pasados 10 minutos del horario establecido, perderá por default.</li>
+                    <li>Dos inasistencias consecutivas descalifican automáticamente a la pareja.</li>
+                </ul>
 
-        <h4 class="font-semibold">Cambios o sustituciones:</h4>
-        <p>No se permiten cambios de jugadores una vez iniciado el torneo, salvo causa de fuerza mayor, justificada ante el comité organizador.</p>
+                <h4 class="font-semibold">Cambios o sustituciones:</h4>
+                <p>No se permiten cambios de jugadores una vez iniciado el torneo, salvo causa de fuerza mayor, justificada ante el comité organizador.</p>
+            </div>
+        </details>
 
-        <h3 class="text-lg font-semibold mt-4">📝 DISPOSICIONES FINALES</h3>
-        <ul class="list-disc pl-6">
-            <li>Cualquier situación no prevista será resuelta por el comité organizador.</li>
-            <li>La participación implica la aceptación total de estas bases y reglamento.</li>
-            <li>El torneo promueve la sana convivencia, por lo que se espera respeto y deportivismo en todo momento.</li>
-            <li>El comité organizador se reserva el derecho de modificar el presente reglamento por causas justificadas.</li>
-        </ul>
+        <details class="mt-4">
+            <summary class="font-semibold cursor-pointer">📝 DISPOSICIONES FINALES</summary>
+            <ul class="list-disc pl-6 mt-2">
+                <li>Cualquier situación no prevista será resuelta por el comité organizador.</li>
+                <li>La participación implica la aceptación total de estas bases y reglamento.</li>
+                <li>El torneo promueve la sana convivencia, por lo que se espera respeto y deportivismo en todo momento.</li>
+                <li>El comité organizador se reserva el derecho de modificar el presente reglamento por causas justificadas.</li>
+            </ul>
+        </details>
     </section>
 
     <section id="playerSection" class="glass-card p-4 mb-10">


### PR DESCRIPTION
## Summary
- wrap game rules and final notes in `<details>` elements
- keep tournament info organized in collapsible cards

## Testing
- `tidy -e frontenis.html`
- `tidy -e index.html` *(fails: lots of warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68714685890083258786056aeb2a3ece