### PR TITLE
Fix password overlay visibility

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -56,7 +56,7 @@
         }
     </style>
 </head>
-<body id="mainContent" class="bg-gray-50 p-4 max-w-2xl mx-auto hidden">
+<body class="bg-gray-50 p-4 max-w-2xl mx-auto">
     <div id="passwordOverlay" class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-75">
         <div class="bg-white p-4 rounded shadow">
             <label for="passwordInput" class="block mb-2">Contraseña:</label>
@@ -65,6 +65,7 @@
             <p id="passwordError" class="text-red-500 mt-2 hidden">Contraseña incorrecta</p>
         </div>
     </div>
+    <div id="mainContent" class="hidden">
     <h1 class="text-2xl font-bold text-center mb-6">Torneo Frontenis 2025</h1>
 
     <section id="infoSection" class="glass-card p-4 mb-10 space-y-2">
@@ -346,6 +347,7 @@
                 </div>
             </form>
         </div>
+    </div>
     </div>
 
 <script type="module">


### PR DESCRIPTION
## Summary
- show password overlay by removing `hidden` from the body tag
- wrap page content in a hidden container so the password check works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871536c2ff483259ed301ace8003d6a