### PR TITLE
Add hero section to Frontenis page

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -13,6 +13,17 @@
             border-radius: 1rem;
             box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
         }
+        .glass-hero {
+            background: rgba(255, 255, 255, 0.25);
+            border-radius: 1rem;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
+            border-top: 2px solid rgba(255, 255, 255, 0.6);
+            border-left: 2px solid rgba(255, 255, 255, 0.6);
+            border-bottom: 2px solid rgba(255, 255, 255, 0.1);
+            border-right: 2px solid rgba(255, 255, 255, 0.1);
+        }
         .modal-overlay {
             position: fixed;
             top: 0;
@@ -66,7 +77,13 @@
         </div>
     </div>
     <div id="mainContent" class="hidden">
-    <h1 class="text-2xl font-bold text-center mb-6">Torneo Frontenis 2025</h1>
+
+    <section id="hero" class="flex items-center justify-center my-8">
+        <div class="glass-hero p-6 text-center">
+            <img src="LogoFrontenis.png" alt="Logo Frontenis" class="w-40 sm:w-60 mx-auto mb-4">
+            <h1 class="text-4xl font-bold">Torneo 2025</h1>
+        </div>
+    </section>
 
     <section id="infoSection" class="glass-card p-4 mb-10 space-y-2">
         <h2 class="text-xl font-semibold mb-4 text-center">Información del Torneo</h2>


### PR DESCRIPTION
## Summary
- style hero section with a beveled glass effect
- add hero section featuring LogoFrontenis.png and "Torneo 2025" text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68717bc0b04c8325b7b02de496b834c2