### PR TITLE
Center hero section as a cover

### DIFF
--- a/frontenis.html
+++ b/frontenis.html
@@ -71,7 +71,7 @@
         }
     </style>
 </head>
-<body class="p-4 max-w-2xl mx-auto">
+<body>
     <div id="passwordOverlay" class="fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-75">
         <div class="bg-white p-4 rounded shadow">
             <label for="passwordInput" class="block mb-2">Contraseña:</label>
@@ -82,12 +82,14 @@
     </div>
     <div id="mainContent" class="hidden">
 
-    <section id="hero" class="flex items-center justify-center my-8">
+    <section id="hero" class="h-screen flex items-center justify-center bg-cover bg-center" style="background-image: url('Fondo.jpg');">
         <div class="glass-hero p-6 text-center">
             <img src="LogoFrontenis.png" alt="Logo Frontenis" class="w-40 sm:w-60 mx-auto mb-4">
             <h1 class="text-4xl font-bold">Torneo 2025</h1>
         </div>
     </section>
+
+    <div class="max-w-2xl mx-auto p-4">
 
     <section id="infoSection" class="glass-card p-4 mb-10 space-y-2">
         <h2 class="text-xl font-semibold mb-4 text-center">Información del Torneo</h2>
@@ -368,6 +370,7 @@
                 </div>
             </form>
         </div>
+    </div>
     </div>
     </div>
 


### PR DESCRIPTION
## Summary
- adjust hero in `frontenis.html` to fill the viewport and use the `Fondo.jpg` background
- wrap the rest of the content in a centered container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687185cb2ecc8325b4d1ab900c4f613c